### PR TITLE
Optimize norm_l1

### DIFF
--- a/phomo/src/metrics.rs
+++ b/phomo/src/metrics.rs
@@ -17,11 +17,15 @@ pub(crate) type MetricFn = fn(&RgbImage, &RgbImage) -> i64;
 /// assert_eq!(norm, 255 * 3 * 2 * 2);
 /// ```
 pub fn norm_l1(img1: &RgbImage, img2: &RgbImage) -> i64 {
-    img1.pixels().zip(img2.pixels()).fold(0, |sum, (p1, p2)| {
-        sum + (p1[0].abs_diff(p2[0]) as i64)
-            + (p1[1].abs_diff(p2[1]) as i64)
-            + (p1[2].abs_diff(p2[2]) as i64)
-    })
+    let data1 = img1.as_raw();
+    let data2 = img2.as_raw();
+    
+    assert_eq!(data1.len(), data2.len(), "Images must have the same number of pixels");
+    
+    data1.iter()
+        .zip(data2.iter())
+        .map(|(byte1, byte2)| i64::from(byte1.abs_diff(*byte2)))
+        .sum()
 }
 
 /// L2 norm, the euclidean distance of the pixels.


### PR DESCRIPTION
I found that norm_l1() was taking about 20% of my total render time (with a cached tile vector), and I was able to speed that function up by 20% by working on the byte level rather than the pixel level, which we can do because (as far as I know) we can assume Rgbimage stores the pixel data as RGBRGBRGBRGB etc with no stride, so bytes[n] of img1 should be the same channel of the same pixel as bytes[n] of img2.